### PR TITLE
Fix bug in MQTTS topic registration (issue #5)

### DIFF
--- a/rsmb/src/MQTTSProtocol.c
+++ b/rsmb/src/MQTTSProtocol.c
@@ -986,9 +986,15 @@ int MQTTSProtocol_handleSubscribes(void* pack, int sock, char* clientAddr, Clien
 		// Topic name
 		if (sub->flags.topicIdType == MQTTS_TOPIC_TYPE_NORMAL && !Topics_hasWildcards(topicName))
 		{
-			char* regTopicName = malloc(strlen(topicName)+1);
-			strcpy(regTopicName, topicName);
-			topicId = (MQTTSProtocol_registerTopic(client, regTopicName))->id;
+		    	ListElement* elem;
+ 		        if ((elem = ListFindItem(client->registrations, topicName, registeredTopicNameCompare)) == NULL)
+			{
+			        char* regTopicName = malloc(strlen(topicName)+1);
+				strcpy(regTopicName, topicName);
+				topicId = (MQTTSProtocol_registerTopic(client, regTopicName))->id;
+			}
+			else
+			        topicId = ((Registration*)(elem->content))->id;
 		}
 		// Pre-defined topic
 		else if (sub->flags.topicIdType == MQTTS_TOPIC_TYPE_PREDEFINED)


### PR DESCRIPTION
If a MQTTS client missed a SUBACK and consequently resent the SUBSCRIBE,
rsmb would send the next SUBACK with a different topic id. But later
PUBLISHes on that topic would use the first topic id which was unknown
to the client.

Fix is to use the same check for a previously registered topic in
MQTTSProtocol_handleSubscribes that MQTTSProtocol_handleRegisters uses.
